### PR TITLE
export_TUIRel

### DIFF
--- a/UMLS-Graph-Extracts.py
+++ b/UMLS-Graph-Extracts.py
@@ -52,6 +52,14 @@ df.to_csv(path_or_buf='TUIs.csv', header=True, index=False)
 print('TUIs.csv: {0} records exported'.format(str(df.size)))
 
 # ------
+# TUIrel.csv
+query = "WITH Semantics as (SELECT DISTINCT UI from {0}.SRDEF WHERE RT = 'STY') SELECT DISTINCT UI3, UI1 FROM {0}.SRSTRE1 INNER JOIN Semantics ON {0}.SRSTRE1.UI1 = Semantics.UI WHERE UI2 = 'T186'".format(args.umlsversion)
+df = pd.read_sql_query(query, engine)
+df.columns =[':END_ID', ':START_ID']
+df.to_csv(path_or_buf='TUIrel.csv', header=True, index=False)
+print('TUIrel.csv: {0} records exported'.format(str(df.size)))
+
+# ------
 # CUIs.csv
 # Concepts from the Metathesaurus that have preferred terms in English.
 


### PR DESCRIPTION
When I converted the original Jupyter notebook to a python script file, I did not include the section that exports to TUIrel.csv. The new version of the script file now includes this section.